### PR TITLE
Track missing downloads

### DIFF
--- a/api/controllers/CfdiController.php
+++ b/api/controllers/CfdiController.php
@@ -95,21 +95,19 @@ class CfdiController {
 
     // descarga todos los seleccionados con concurrencia 50 (lo maneja Guzzle)
     $downloadList = new MetadataList($cfdisToDownload);
-    $descargados = [];
 
     $resultados = $satScraper->resourceDownloader($resourceType, $downloadList)
         ->setConcurrency(30) // Puedes ajustar el número
         ->saveTo(DESCARGA_PATH, true, 0777);
 
-    // $resultados es un array de UUIDs descargados exitosamente
-    foreach ($resultados as $uuid) {
-        $descargados[] = $uuid;
-    }
+    $descargados = $resultados;
+    $faltantes = array_values(array_diff($selectedUuids, $descargados));
 
     Response::json([
         'status' => 'OK',
         'msg' => 'Descarga completada.',
         'descargados' => $descargados,
+        'noDescargados' => $faltantes,
         'avisos' => $metadataHandler->avisos,
     ]);
 }


### PR DESCRIPTION
## Summary
- simplify collecting download results
- report UUIDs that were not downloaded

## Testing
- `php -l api/controllers/CfdiController.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68645eb531248324b39221fbb4fe2552