### PR TITLE
Handle SAT inactive session in UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ api/error.log
 .DS_Store
 Thumbs.db
 *.tmp
+node_modules/

--- a/js/cfdi-ui.js
+++ b/js/cfdi-ui.js
@@ -4,6 +4,7 @@ import { loginSat, logoutSat, statusSat, searchCfdi, downloadCfdi } from './cfdi
 
 let satSessionErrorCount = 0;
 const SAT_SESSION_ERROR_MSG = "expected to have the session registered";
+const SAT_SESSION_INACTIVE_MSG = "No hay sesión activa SAT para este RFC";
 const SAT_SESSION_MAX_RETRIES = 3;
 
 window.debugMode = false; // global for debugLog
@@ -554,7 +555,7 @@ async function realizarDescarga(uuids, formData) {
 // ==============================
 
 function handleSatSessionError(errorMsg) {
-    if (errorMsg && errorMsg.includes(SAT_SESSION_ERROR_MSG)) {
+    if (errorMsg && (errorMsg.includes(SAT_SESSION_ERROR_MSG) || errorMsg.includes(SAT_SESSION_INACTIVE_MSG))) {
         satSessionErrorCount++;
         if (satSessionErrorCount < SAT_SESSION_MAX_RETRIES) {
             showToast("El SAT tardó en reconocer la sesión. Vuelve a intentar la operación.", "warning");

--- a/test/handleSatSessionError.test.js
+++ b/test/handleSatSessionError.test.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+const file = fs.readFileSync('js/cfdi-ui.js','utf8');
+const fn = file.match(/function handleSatSessionError[^]*?\n}/)[0];
+
+function loadContext() {
+  const ctx = {
+    SAT_SESSION_ERROR_MSG: 'expected to have the session registered',
+    SAT_SESSION_INACTIVE_MSG: 'No hay sesión activa SAT para este RFC',
+    SAT_SESSION_MAX_RETRIES: 3,
+    satSessionErrorCount: 0,
+    showToast: function(){},
+    estadoCalled: null,
+    mostrarEstadoSesion: function(activa, mensaje){ ctx.estadoCalled = [activa, mensaje]; }
+  };
+  vm.createContext(ctx);
+  vm.runInContext(fn, ctx);
+  return ctx;
+}
+
+(function testErrorMsg() {
+  const ctx = loadContext();
+  const msg = 'error: expected to have the session registered';
+  assert.strictEqual(ctx.handleSatSessionError(msg), true);
+  assert.strictEqual(ctx.satSessionErrorCount, 1);
+  assert.strictEqual(ctx.handleSatSessionError(msg), true);
+  assert.strictEqual(ctx.satSessionErrorCount, 2);
+  assert.strictEqual(ctx.handleSatSessionError(msg), true);
+  assert.strictEqual(ctx.satSessionErrorCount, 0);
+  assert.deepStrictEqual(ctx.estadoCalled, [false, 'Sesión expirada']);
+})();
+
+(function testInactiveMsg() {
+  const ctx = loadContext();
+  const msg = 'No hay sesión activa SAT para este RFC. Por favor inicia sesión primero.';
+  assert.strictEqual(ctx.handleSatSessionError(msg), true);
+  assert.strictEqual(ctx.satSessionErrorCount, 1);
+  assert.strictEqual(ctx.handleSatSessionError(msg), true);
+  assert.strictEqual(ctx.satSessionErrorCount, 2);
+  assert.strictEqual(ctx.handleSatSessionError(msg), true);
+  assert.strictEqual(ctx.satSessionErrorCount, 0);
+  assert.deepStrictEqual(ctx.estadoCalled, [false, 'Sesión expirada']);
+})();
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- detect inactive session message in `handleSatSessionError`
- ignore `node_modules` in git
- add unit test verifying both session error messages trigger relogin flow

## Testing
- `node test/handleSatSessionError.test.js`

------
https://chatgpt.com/codex/tasks/task_b_68655799c8008324af19329ad3fba6e3