### PR TITLE
Fix session error retry logic

### DIFF
--- a/js/cfdi-ui.js
+++ b/js/cfdi-ui.js
@@ -621,8 +621,12 @@ async function realizarDescarga(uuids, formData) {
 
 async function handleSatSessionError(errorMsg, retryCallback) {
     if (errorMsg && (errorMsg.includes(SAT_SESSION_ERROR_MSG) || errorMsg.includes(SAT_SESSION_INACTIVE_MSG))) {
-        satSessionErrorCount = 0;
-        return false;
+        satSessionErrorCount++;
+        if (satSessionErrorCount >= SAT_SESSION_MAX_RETRIES) {
+            mostrarEstadoSesion(false, "Sesión expirada");
+            satSessionErrorCount = 0;
+        }
+        return true;
     }
 
     if (satSessionErrorCount >= SAT_SESSION_MAX_RETRIES) {

--- a/test/handleSatSessionError.test.js
+++ b/test/handleSatSessionError.test.js
@@ -3,7 +3,7 @@ const vm = require('vm');
 const assert = require('assert');
 
 const file = fs.readFileSync('js/cfdi-ui.js','utf8');
-const fn = file.match(/function handleSatSessionError[^]*?\n}/)[0];
+const fn = file.match(/async function handleSatSessionError[^]*?\n}/)[0];
 
 function loadContext() {
   const ctx = {
@@ -13,33 +13,35 @@ function loadContext() {
     satSessionErrorCount: 0,
     showToast: function(){},
     estadoCalled: null,
-    mostrarEstadoSesion: function(activa, mensaje){ ctx.estadoCalled = [activa, mensaje]; }
+    mostrarEstadoSesion: function(activa, mensaje){ ctx.estadoCalled = [activa, mensaje]; },
+    loginSat: async () => ({success: true, msg: 'ok'}),
+    $: () => ({ value: 'dummy', trim(){ return this.value; } })
   };
   vm.createContext(ctx);
   vm.runInContext(fn, ctx);
   return ctx;
 }
 
-(function testErrorMsg() {
+(async function testErrorMsg(){
   const ctx = loadContext();
   const msg = 'error: expected to have the session registered';
-  assert.strictEqual(ctx.handleSatSessionError(msg), true);
+  assert.strictEqual(await ctx.handleSatSessionError(msg), true);
   assert.strictEqual(ctx.satSessionErrorCount, 1);
-  assert.strictEqual(ctx.handleSatSessionError(msg), true);
+  assert.strictEqual(await ctx.handleSatSessionError(msg), true);
   assert.strictEqual(ctx.satSessionErrorCount, 2);
-  assert.strictEqual(ctx.handleSatSessionError(msg), true);
+  assert.strictEqual(await ctx.handleSatSessionError(msg), true);
   assert.strictEqual(ctx.satSessionErrorCount, 0);
   assert.deepStrictEqual(ctx.estadoCalled, [false, 'Sesión expirada']);
 })();
 
-(function testInactiveMsg() {
+(async function testInactiveMsg(){
   const ctx = loadContext();
   const msg = 'No hay sesión activa SAT para este RFC. Por favor inicia sesión primero.';
-  assert.strictEqual(ctx.handleSatSessionError(msg), true);
+  assert.strictEqual(await ctx.handleSatSessionError(msg), true);
   assert.strictEqual(ctx.satSessionErrorCount, 1);
-  assert.strictEqual(ctx.handleSatSessionError(msg), true);
+  assert.strictEqual(await ctx.handleSatSessionError(msg), true);
   assert.strictEqual(ctx.satSessionErrorCount, 2);
-  assert.strictEqual(ctx.handleSatSessionError(msg), true);
+  assert.strictEqual(await ctx.handleSatSessionError(msg), true);
   assert.strictEqual(ctx.satSessionErrorCount, 0);
   assert.deepStrictEqual(ctx.estadoCalled, [false, 'Sesión expirada']);
 })();


### PR DESCRIPTION
## Summary
- adjust session error handling to correctly count retries and mark session expired
- update tests for handleSatSessionError to run asynchronously

## Testing
- `node test/handleSatSessionError.test.js`

------
https://chatgpt.com/codex/tasks/task_b_686569ecade88324a4a297d38057a285